### PR TITLE
Fix improperly closed tags and utilize top container for inserting div

### DIFF
--- a/app/code/community/SomethingDigital/SkipToContent/etc/config.xml
+++ b/app/code/community/SomethingDigital/SkipToContent/etc/config.xml
@@ -10,7 +10,7 @@
         <layout>
             <updates>
                 <skiptocontent>
-                    <file>somethingdigital_skiptocontent.xml</file>>
+                    <file>somethingdigital_skiptocontent.xml</file>
                 </skiptocontent>
             </updates>
         </layout>

--- a/app/design/frontend/base/default/layout/somethingdigital_skiptocontent.xml
+++ b/app/design/frontend/base/default/layout/somethingdigital_skiptocontent.xml
@@ -5,12 +5,12 @@
             <block type="core/text" name="skip.to.content.link" before="-">
                 <action method="setText" translate="text">
                     <text><![CDATA[
-                    <a href="#main-content-skip" class="visuallyhidden focusable">Skip to main content>
+                    <a href="#main-content-skip" class="visuallyhidden focusable">Skip to main content</a>
                     ]]></text>
                 </action>
             </block>
         </reference>
-        <reference name="content">
+        <reference name="top.container">
             <block type="core/text" name="skip.to.content.link.content" before="-">
                 <action method="setText" translate="text">
                     <text><![CDATA[


### PR DESCRIPTION
- fixes 2 improperly closed divs
- changes empty helper div hook to use top.container in order to keep page title in view (specific to this page compared to header)
