### PR TITLE
Add negative tabindex to skip target

### DIFF
--- a/app/design/frontend/base/default/layout/somethingdigital_skiptocontent.xml
+++ b/app/design/frontend/base/default/layout/somethingdigital_skiptocontent.xml
@@ -14,7 +14,7 @@
             <block type="core/text" name="skip.to.content.link.content" before="-">
                 <action method="setText" translate="text">
                     <text><![CDATA[
-                    <div id="main-content-skip"></div>
+                    <div id="main-content-skip" tabindex="-1"></div>
                     ]]></text>
                 </action>
             </block>


### PR DESCRIPTION
> You should include a tabindex="-1" on the target of the skip link. IE and Chrome both require this attribute to be present to make the skip link work consistently.
> https://accessibility.oit.ncsu.edu/training/accessibility-handbook/skip-to-main-content.html

Without this, Chrome and IE don't focus on the skip target.
